### PR TITLE
[docker]: update openjdk-8 version for ubuntu 16.04

### DIFF
--- a/Dockerfiles/BUILD/Dockerfile
+++ b/Dockerfiles/BUILD/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update -y && \
-    apt-get install -y git curl gnupg-curl openjdk-8-jdk=8u131-b11-0ubuntu1.16.04.2 && \
+    apt-get install -y git curl gnupg-curl openjdk-8-jdk=8u131-b11-2ubuntu1.16.04.3 && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean


### PR DESCRIPTION
Without this update the build of the image would fail