### PR TITLE
Adding rsk directory in LOG_PATH constant

### DIFF
--- a/rskj-ubuntu-installer/rskj_package_xenial/debian/rskj.postinst
+++ b/rskj-ubuntu-installer/rskj_package_xenial/debian/rskj.postinst
@@ -10,7 +10,7 @@ NODE_SERVICE="/lib/systemd/system/rsk.service"
 HOME_PATH="/var/lib/rsk"
 JAR_PATH="/usr/share/rsk"
 CONF_PATH="/etc/rsk"
-LOG_PATH="/var/log"
+LOG_PATH="/var/log/rsk"
 
 JAVA=$(which java)
 SOLC_PATH=$(which solc || echo /bin/false)

--- a/rskj-ubuntu-installer/rskj_package_zesty/debian/rskj.postinst
+++ b/rskj-ubuntu-installer/rskj_package_zesty/debian/rskj.postinst
@@ -10,7 +10,7 @@ NODE_SERVICE="/lib/systemd/system/rsk.service"
 HOME_PATH="/var/lib/rsk"
 JAR_PATH="/usr/share/rsk"
 CONF_PATH="/etc/rsk"
-LOG_PATH="/var/log"
+LOG_PATH="/var/log/rsk"
 
 JAVA=$(which java)
 SOLC_PATH=$(which solc || echo /bin/false)


### PR DESCRIPTION
Missing "rsk" directory in LOG_PATH, its OK in trusty build postinst