### PR TITLE
Update migration.properties

### DIFF
--- a/migrations/0.4.1/migration.properties
+++ b/migrations/0.4.1/migration.properties
@@ -1,4 +1,4 @@
 peer.discovery.bind.ip = bind.address
 peer.listen.port = peer.port
 peer.external.ip = public.ip
-rpc.host = rpc.address
+[new] rpc.host = ["localhost"]


### PR DESCRIPTION
Fix: RPC host is a new key (not an existing one).