### PR TITLE
Don't use SIGKILL to stop rskj

### DIFF
--- a/rskj-ubuntu-installer/init-scripts/rsk.service-node
+++ b/rskj-ubuntu-installer/init-scripts/rsk.service-node
@@ -3,10 +3,7 @@ Description=RSK Node
 
 [Service]
 LimitNOFILE=500000
-Type=simple
-ExecStart=<JAVA_PATH> -Dlogback.configurationFile='/etc/rsk/logback.xml' -cp /usr/share/rsk/rsk.jar co.rsk.Start 2>&1 &
-ExecStop=/bin/kill -9 $(/bin/ps -U rsk -o pid h)
-PIDFile=/var/run/rsk.pid
+ExecStart=<JAVA_PATH> -Dlogback.configurationFile='/etc/rsk/logback.xml' -cp /usr/share/rsk/rsk.jar co.rsk.Start 2>&1
 User=rsk
 
 [Install]


### PR DESCRIPTION
Run the process in foreground and let systemd take care of stopping
it.

While there, remove `PIDFile` as we don't create one and `Type` as
`simple` is the default.

Signed-off-by: Lucas Gabriel Vuotto <lucas@rsk.co>