### PR TITLE
Adds docker-compose deployment artifact and simple readme

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,6 +1,6 @@
 # RSK docker-compose
 
-This `docker-compose.yml` uses the [official docker hub images of rsksmart](https://hub.docker.com/u/rsksmart) and the configurations for the [dockerfiles](https://github.com/rsksmart/artifacts/tree/master/Dockerfiles/RSK-Node) on this docs for setting up rsk mainnet/testnet nodes 
+This `docker-compose.yml` Uses the dockerfiles images and configurations [here](https://github.com/rsksmart/artifacts/tree/master/Dockerfiles/RSK-Node) on this docs for setting up rsk mainnet/testnet nodes 
 
 ## Example Usage
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,8 @@
+# RSK docker-compose
+
+This `docker-compose.yml` uses the [official docker hub images of rsksmart](https://hub.docker.com/u/rsksmart) and the configurations for the [dockerfiles](https://github.com/rsksmart/artifacts/tree/master/Dockerfiles/RSK-Node) on this docs for setting up rsk mainnet/testnet nodes 
+
+## Example Usage
+
+> docker-compose up
+

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -4,5 +4,9 @@ This `docker-compose.yml` uses the [official docker hub images of rsksmart](http
 
 ## Example Usage
 
+For running
 > docker-compose up
 
+For debugging/check current sync logs
+> docker ps (Verify the container id you want to check)
+>  docker exec -it <container-id> tail -f /var/log/rsk/rsk.log 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "4444"
       - "50505"
     volumes:
-      - rsk-testnet:/var/lib/rsk/database/testnet
+      - rsk-testnet:/var/lib/rsk/database
     networks:
       - rsk
 
@@ -18,7 +18,7 @@ services:
       - "4444"
       - "5050"
     volumes:
-      - rsk-mainnet:/var/lib/rsk/database/mainnet
+      - rsk-mainnet:/var/lib/rsk/database
     networks:
       - rsk
  

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,7 +3,10 @@ version: '2.1'
 services:
  
   rsk-testnet:
-    image: rsksmart/rskj-testnet:latest
+    image: rsk-testnet 
+    build:
+      context: ../Dockerfiles/RSK-Node/
+      dockerfile: Dockerfile.MainNet
     expose:
       - "4444"
       - "50505"
@@ -13,7 +16,10 @@ services:
       - rsk
 
   rsk-mainnet:
-    image: rsksmart/rskj-standalone:latest
+    image: rsk-mainnet 
+    build:
+      context: ../Dockerfiles/RSK-Node/
+      dockerfile: Dockerfile.MainNet
     expose:
       - "4444"
       - "5050"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2.1'
+
+services:
+ 
+  rsk-testnet:
+    image: rsksmart/rskj-testnet:latest
+    expose:
+      - "4444"
+      - "50505"
+    volumes:
+      - rsk-testnet:/var/lib/rsk/database/testnet
+    networks:
+      - pocket
+
+  rsk-mainnet:
+    image: rsksmart/rskj-standalone:latest
+    expose:
+      - "4444"
+      - "5050"
+    volumes:
+      - rsk-mainnet:/var/lib/rsk/database/mainnet
+    networks:
+      - pocket
+ 
+volumes:
+  rsk-mainnet:
+  rsk-testnet:
+
+networks:
+  pocket:
+    driver: bridge

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - rsk-testnet:/var/lib/rsk/database/testnet
     networks:
-      - pocket
+      - rsk
 
   rsk-mainnet:
     image: rsksmart/rskj-standalone:latest
@@ -20,12 +20,12 @@ services:
     volumes:
       - rsk-mainnet:/var/lib/rsk/database/mainnet
     networks:
-      - pocket
+      - rsk
  
 volumes:
   rsk-mainnet:
   rsk-testnet:
 
 networks:
-  pocket:
+  rsk:
     driver: bridge


### PR DESCRIPTION
Adds docker-compose.yml with:

- Both mainnet/testnet rsk nodes built with the [rsk dockerfiles](https://github.com/rsksmart/artifacts/tree/master/Dockerfiles/RSK-Node) in this repo 
- Dead simple readme.md about how to use it
- Adds volumes persistence for keeping the database
